### PR TITLE
Ignore direct messages

### DIFF
--- a/lib/reaction-issue-filer.js
+++ b/lib/reaction-issue-filer.js
@@ -26,6 +26,11 @@ ReactionIssueFiler.prototype.parseMetadata = function(getReactionsResponse,
 };
 
 ReactionIssueFiler.prototype.execute = function(message) {
+  // Ignore direct messages
+  if(message.item.channel[0] === 'D') {
+    return Promise.reject();
+  }
+
   var filer = this;
   return new Promise(function(resolve, reject) {
     var messageId, impl;

--- a/tests/reaction-issue-filer-test.js
+++ b/tests/reaction-issue-filer-test.js
@@ -110,6 +110,7 @@ describe('ReactionIssueFiler', function() {
       message.item.channel = 'D5150OU812';
       return reactor.execute(message).should.be.rejectedWith(null)
         .then(function() {
+          slackClient.messageId.calledOnce.should.be.false;
           messageLock.lock.calledOnce.should.be.false;
           messageLock.unlock.calledOnce.should.be.false;
         });

--- a/tests/reaction-issue-filer-test.js
+++ b/tests/reaction-issue-filer-test.js
@@ -106,6 +106,15 @@ describe('ReactionIssueFiler', function() {
       messageLock.unlock.returns(Promise.resolve(helpers.MESSAGE_ID));
     });
 
+    it('should ignore direct messages', function() {
+      message.item.channel = 'D5150OU812';
+      return reactor.execute(message).should.be.rejectedWith(null)
+        .then(function() {
+          messageLock.lock.calledOnce.should.be.false;
+          messageLock.unlock.calledOnce.should.be.false;
+        });
+    });
+
     it('should receive a message and file an issue', function() {
       return reactor.execute(message)
         .should.become(helpers.ISSUE_URL).then(function() {


### PR DESCRIPTION
From #2, the bot responds with an error message any time a reaction is added to a message in a DM.  My gut is that adding Github issues from DMs doesn't make a lot of sense, so I went with the simplest solution and just ignore reactions on DMs.