### PR TITLE
Fix private channel handling

### DIFF
--- a/lib/slack-rtm-data-store.js
+++ b/lib/slack-rtm-data-store.js
@@ -12,7 +12,13 @@ SlackRtmDataStore.prototype.teamId = function() {
 };
 
 SlackRtmDataStore.prototype.channelById = function(channelId) {
-  return Promise.resolve(this.rtmClient.dataStore.getChannelById(channelId));
+  // Public channels are in the channels list, while private
+  // channels are in the groups list.
+  if(channelId[0] === 'C') {
+    return Promise.resolve(this.rtmClient.dataStore.getChannelById(channelId));
+  } else {
+    return Promise.resolve(this.rtmClient.dataStore.getGroupById(channelId));
+  }
 };
 
 SlackRtmDataStore.prototype.teamInfo = function() {

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -11,6 +11,8 @@ exports = module.exports = {
   ITEM_USER_ID: 'U1984OU812',
   CHANNEL_ID: 'C5150OU812',
   CHANNEL_NAME: 'bot-dev',
+  PRIVATE_CHANNEL_ID: 'G5150OU812',
+  PRIVATE_CHANNEL_NAME: 'private-bot-dev',
   TIMESTAMP: '1360782804.083113',
   PERMALINK: 'https://mbland.slack.com/archives/bot-dev/p1360782804083113',
   ISSUE_URL: 'https://github.com/mbland/slack-github-issues/issues/1',
@@ -25,6 +27,9 @@ exports = module.exports = {
       dataStore: {
         getChannelById: function(channelId) {
           return { id: channelId, name: exports.CHANNEL_NAME };
+        },
+        getGroupById: function(groupId) {
+          return { id: groupId, name: exports.PRIVATE_CHANNEL_NAME };
         },
         teams: {
           T19845150: { domain: exports.TEAM_DOMAIN }

--- a/tests/slack-rtm-data-store-test.js
+++ b/tests/slack-rtm-data-store-test.js
@@ -19,9 +19,15 @@ describe('SlackRtmDataStore', function() {
     rtmDataStore.teamId().should.equal(helpers.TEAM_ID);
   });
 
-  it('returns a Promise from channelById', function() {
+  it('returns a Promise from channelById with public channel', function() {
     return rtmDataStore.channelById(helpers.CHANNEL_ID)
       .should.become({ id: helpers.CHANNEL_ID, name: helpers.CHANNEL_NAME });
+  });
+
+  it('returns a Promise from channelById with private channel', function() {
+    return rtmDataStore.channelById(helpers.PRIVATE_CHANNEL_ID)
+      .should.become({ id: helpers.PRIVATE_CHANNEL_ID,
+        name: helpers.PRIVATE_CHANNEL_NAME });
   });
 
   it('returns a Promise from teamInfo', function() {


### PR DESCRIPTION
Addresses #2.

The Slack API treats public and private channels as different types of entities: public ones are "channels" and private ones are "groups."  So, a reaction added in a private channel was causing the channel information to come out undefined, which ultimately led to an exception that was reported in the channel.

To handle it, check if the channel is public.  If it is, continue down the prior path; if not, try to get the info from the list of groups instead of the list of channels.