### PR TITLE
filer: Ignore reactions to files, file comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ the `ReactionIssueFiler` will [react to the message with a `successReaction`
 emoji](https://api.slack.com/methods/reactions.add). Finally, it will return the
 issue URL to the application.
 
+**Note:** This plugin only handles reactions to normal messages, not file or
+file comment reactions. This support may be added in the future if the demand
+exists, but isn't straightforward, since there's no one specific channel
+associated with either.
+
 ## <a id='whats-different'></a>What's different from mbland/hubot-slack-github-issues?
 
 This package has been refactored heavily to ensure the core logic is 100%

--- a/lib/reaction-issue-filer.js
+++ b/lib/reaction-issue-filer.js
@@ -26,8 +26,11 @@ ReactionIssueFiler.prototype.parseMetadata = function(getReactionsResponse,
 };
 
 ReactionIssueFiler.prototype.execute = function(message) {
-  // Ignore direct messages
-  if (message.item.channel[0] === 'D') {
+  // Ignore reactions to files, file comments, and direct messages. In the
+  // future, we may want to support file and file comment reactions, but it's
+  // not straightforward, since there's no one specific channel associated with
+  // either.
+  if (message.item.channel === undefined || message.item.channel[0] === 'D') {
     return Promise.reject();
   }
 

--- a/tests/reaction-issue-filer-test.js
+++ b/tests/reaction-issue-filer-test.js
@@ -106,6 +106,19 @@ describe('ReactionIssueFiler', function() {
       messageLock.unlock.returns(Promise.resolve(helpers.MESSAGE_ID));
     });
 
+    it('should ignore reactions that aren\'t for normal messages', function() {
+      message.item = {
+        type: 'file',
+        file: 'F5150OU812'
+      };
+      return reactor.execute(message).should.be.rejectedWith(null)
+        .then(function() {
+          slackClient.messageId.calledOnce.should.be.false;
+          messageLock.lock.calledOnce.should.be.false;
+          messageLock.unlock.calledOnce.should.be.false;
+        });
+    });
+
     it('should ignore direct messages', function() {
       message.item.channel = 'D5150OU812';
       return reactor.execute(message).should.be.rejectedWith(null)


### PR DESCRIPTION
This was causing errors to appear in the logs since reactions were getting added to other objects:
```
  [Wed Apr 19 2017 08:59:53 GMT+0200 (CEST)] ERROR TypeError: Cannot read property '0' of undefined
    at ReactionIssueFiler.execute (.../node_modules/slack-github-issues/lib/reaction-issue-filer.js:30:27)
```
In the future, we may want to support file and file comment reactions, but it's not straightforward, since there's no one specific channel or timestamp associated with either.

cc @kenock @mgwalker 