### PR TITLE
./go: Update to v1.5.0, download on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .*.swp
 coverage/*
 node_modules/
+scripts/go-script-bash/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/go-script-bash"]
-	path = scripts/go-script-bash
-	url = https://github.com/mbland/go-script-bash

--- a/go
+++ b/go
@@ -1,12 +1,30 @@
 #! /usr/bin/env bash
 
-declare -r __GO_CORE="${0%/*}/scripts/go-script-bash/go-core.bash"
 
-if [[ ! -f "$__GO_CORE" ]]; then
-  git submodule update --init
+# The path where the command scripts reside
+declare GO_SCRIPTS_DIR="${GO_SCRIPTS_DIR:-scripts}"
+
+# The `GO_SCRIPT_BASH_REPO_URL` tag or branch
+declare GO_SCRIPT_BASH_VERSION="${GO_SCRIPT_BASH_VERSION:-v1.5.0}"
+
+# The go-script-bash installation directory within the project
+declare GO_SCRIPT_BASH_CORE_DIR="${GO_SCRIPT_BASH_CORE_DIR:-${0%/*}/$GO_SCRIPTS_DIR/go-script-bash}"
+
+# The URL of the go-script-bash framework sources
+declare GO_SCRIPT_BASH_REPO_URL="${GO_SCRIPT_BASH_REPO_URL:-https://github.com/mbland/go-script-bash.git}"
+
+if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
+  printf "Cloning framework from '%s'...\n" "$GO_SCRIPT_BASH_REPO_URL"
+  if ! git clone --depth 1 -c advice.detachedHead=false \
+      -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
+      "$GO_SCRIPT_BASH_CORE_DIR"; then
+    printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
+    exit 1
+  fi
+  printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
 fi
 
-. "$__GO_CORE" "scripts"
+. "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"
 . "$_GO_USE_MODULES" 'log'
 
 export PATH="node_modules/.bin:$PATH"


### PR DESCRIPTION
With the updates to the `./go` script from the upstream `go-template` file, it's no longer necessary to have `mbland/go-script-bash` attached to this repository as a submodule.

After pulling in this commit, run `rm -rf script/go-script-bash` to download the new version of `mbland/go-script-bash` upon the next invocation of the `./go` script.